### PR TITLE
Add power limit read/write support (M10/M11 hardware-aware)

### DIFF
--- a/probe.py
+++ b/probe.py
@@ -1,0 +1,110 @@
+"""Command-line probe: test the zeversolar library against a real inverter.
+
+Usage:
+    python probe.py <host> [--write]
+    python probe.py 192.168.2.22
+    python probe.py 192.168.2.22 --write   # also tests write path (restores state)
+
+Read-only by default. Pass --write to also exercise set_power_limit, which
+will temporarily change the limit to 90% and then restore the original value.
+The device is always left in the state it was found in.
+"""
+
+import sys
+import time
+import dataclasses
+import urllib.parse
+
+import requests
+
+from zeversolar import ZeverSolarClient, ZeverSolarPowerLimitData
+from zeversolar.exceptions import ZeverSolarInvalidData, ZeverSolarPowerLimitNotSupported
+
+
+def fetch_raw(host: str, path: str) -> str:
+    """Fetch a raw CGI endpoint and return the response body."""
+    netloc = urllib.parse.urlparse(f"http://{host}").netloc or host
+    url = f"http://{netloc}/{path}"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.text
+
+
+def print_fields(obj: object) -> None:
+    for field in dataclasses.fields(obj):  # type: ignore[arg-type]
+        print(f"  {field.name}: {getattr(obj, field.name)}")
+
+
+def wait_for_limit(client: ZeverSolarClient, target_pct: int, timeout: int = 120) -> bool:
+    """Poll get_power_limit() until it reaches target_pct or timeout expires."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        current = client.get_power_limit().limit_pct
+        print(f"  ... {current}%")
+        if current == target_pct:
+            return True
+        time.sleep(5)
+    return False
+
+
+def test_write(client: ZeverSolarClient, original: ZeverSolarPowerLimitData) -> None:
+    """Exercise set_power_limit and restore state unconditionally."""
+    target = 90 if original.limit_pct != 90 else 80
+    print(f"\n=== set_power_limit({target}%) ===")
+    print(f"  Saving original: limit_pct={original.limit_pct}, mode={original.mode}")
+    try:
+        client.set_power_limit(target)
+        if wait_for_limit(client, target):
+            print("  Write verified ✓")
+        else:
+            print(f"  Timed out waiting for {target}%")
+    finally:
+        print(f"\n=== Restoring original limit ({original.limit_pct}%) ===")
+        client.set_power_limit(original.limit_pct)
+        if wait_for_limit(client, original.limit_pct):
+            print("  Restore verified ✓")
+        else:
+            print(f"  WARNING: restore timed out (readback may not be {original.limit_pct}%)")
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python probe.py <host> [--write]")
+        print("Example: python probe.py 192.168.2.22")
+        sys.exit(1)
+
+    host = sys.argv[1]
+    write_mode = "--write" in sys.argv
+    print(f"Connecting to {host} ...\n")
+
+    client = ZeverSolarClient(host=host)
+
+    print("=== get_data() ===")
+    data = client.get_data()
+    print_fields(data)
+
+    print("\n=== get_power_limit() ===")
+    original_limit = None
+    try:
+        original_limit = client.get_power_limit()
+        print_fields(original_limit)
+    except ZeverSolarPowerLimitNotSupported:
+        print("  Not supported by this inverter.")
+    except ZeverSolarInvalidData:
+        print("  ZeverSolarInvalidData — raw adv.cgi response follows for diagnosis:")
+        try:
+            raw = fetch_raw(host, "adv.cgi")
+            for i, line in enumerate(raw.splitlines()):
+                print(f"  line {i:2d}: {line!r}")
+        except Exception as exc:
+            print(f"  Could not fetch adv.cgi: {exc}")
+
+    if write_mode:
+        if original_limit is None:
+            print("\n--write skipped: get_power_limit() failed above.")
+        else:
+            test_write(client, original_limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/zeversolar/__init__.py
+++ b/src/zeversolar/__init__.py
@@ -1,22 +1,43 @@
 import dataclasses
+import threading
+import time
 import typing
 import urllib.parse
+from collections.abc import Callable
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum
 
 import retry
 import requests
 
-from zeversolar.exceptions import ZeverSolarTimeout, ZeverSolarHTTPError, ZeverSolarHTTPNotFound, ZeverSolarInvalidData, \
-    ZeverSolarError
+from zeversolar.exceptions import (
+    ZeverSolarError,
+    ZeverSolarHTTPError,
+    ZeverSolarHTTPNotFound,
+    ZeverSolarInvalidData,
+    ZeverSolarPowerLimitNotSupported,
+    ZeverSolarTimeout,
+)
 
 kWh = typing.NewType("kWh", float)  # pragma: no mutate
 Watt = typing.NewType("Watt", int)  # pragma: no mutate
+
+MINIMUM_LIMIT: int = 5    # % — inverter won't accept lower
+RAMP_STEP: int = 10       # % per ramp step
+RAMP_RATE_UP: int = 10    # seconds between steps when increasing output
+RAMP_RATE_DOWN: int = 20  # seconds between steps when decreasing output
 
 
 class PowerMode(IntEnum):
     ON = 0
     OFF = 1
+
+
+class PowerLimitMode(IntEnum):
+    PERCENTAGE = 1  # % of inverter AC capacity
+    WATT = 2        # W based on energy meter
+    DRM7 = 3        # AS DRM7 Q command
+    DRM_LOAD = 4    # AS DRMs Safety load speed
 
 
 class Values(IntEnum):
@@ -53,6 +74,12 @@ class ZeverSolarData:
     energy_today: kWh
     status: StatusEnum
     meter_status: StatusEnum
+
+
+@dataclasses.dataclass
+class ZeverSolarPowerLimitData:
+    mode: PowerLimitMode
+    limit_pct: int
 
 
 class ZeverSolarParser:
@@ -159,6 +186,8 @@ class ZeverSolarClient:
         self.host = urllib.parse.urlparse(url=host).netloc.strip("/")
         self._timeout = timedelta(seconds=10).total_seconds()
         self._serial_number: typing.Optional[str] = None
+        self._hardware_version: typing.Optional[str] = None
+        self._ramp_stop: threading.Event = threading.Event()
 
     @retry.retry(exceptions=(ZeverSolarTimeout, ZeverSolarInvalidData), tries=3)  # pragma: no mutate
     def get_data(self) -> ZeverSolarData:
@@ -176,13 +205,173 @@ class ZeverSolarClient:
                 raise ZeverSolarHTTPNotFound() from exception
             raise ZeverSolarHTTPError() from exception
 
-        return ZeverSolarParser(zeversolar_response=response.text).parse()
+        data = ZeverSolarParser(zeversolar_response=response.text).parse()
+        self._hardware_version = data.hardware_version
+        return data
 
-    def power_on(self) -> PowerMode:
-        return self.ctrl_power(mode=PowerMode.ON)
+    def get_power_limit(self) -> ZeverSolarPowerLimitData:
+        """Read current power limit from adv.cgi. Works on M10 and M11."""
+        try:
+            response = requests.get(url=f"http://{self.host}/adv.cgi", timeout=self._timeout)
+        except requests.exceptions.Timeout as exception:
+            raise ZeverSolarTimeout() from exception
+        except Exception as exception:
+            raise ZeverSolarError() from exception
 
-    def power_off(self) -> PowerMode:
-        return self.ctrl_power(mode=PowerMode.OFF)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exception:
+            if response.status_code == 404:
+                raise ZeverSolarPowerLimitNotSupported() from exception
+            raise ZeverSolarHTTPError() from exception
+
+        # adv.cgi returns one field per line (0-indexed):
+        #   line 11 = ac_value1 — current power limit %
+        #   line 13 = ac_mode   — active limit mode
+        lines = response.text.splitlines()
+        if len(lines) < 14:
+            raise ZeverSolarInvalidData()
+
+        try:
+            limit_pct = int(float(lines[11].strip()))
+            mode = PowerLimitMode(int(lines[13].strip()))
+        except (ValueError, KeyError) as exception:
+            raise ZeverSolarInvalidData() from exception
+
+        return ZeverSolarPowerLimitData(mode=mode, limit_pct=limit_pct)
+
+    def set_power_limit(
+        self,
+        limit_pct: int,
+        ramp_rate: int | None = None,
+        on_step: Callable[[int], None] | None = None,
+    ) -> None:
+        """Start ramping output to target percentage. Returns immediately.
+
+        Cancels any ramp already in progress and starts a fresh daemon thread.
+        The ramp runs in the background; on_step is called from that thread
+        after each write (must be thread-safe in HA context).
+
+        ramp_rate controls step size in %:
+          - None (default): RAMP_STEP (10%) steps
+          - 100: single write, jumps directly to target
+          - 5: finer 5% steps for a more gradual transition
+
+        Sleep between steps is fixed by direction: RAMP_RATE_UP when
+        increasing, RAMP_RATE_DOWN when decreasing.
+        """
+        # Signal any running ramp to stop, then issue a fresh stop event for
+        # the new ramp so the old and new threads don't share state.
+        self._ramp_stop.set()
+        self._ramp_stop = threading.Event()
+
+        thread = threading.Thread(
+            target=self._do_ramp,
+            args=(limit_pct, ramp_rate, on_step, self._ramp_stop),
+            daemon=True,
+        )
+        thread.start()
+
+    def _do_ramp(
+        self,
+        limit_pct: int,
+        ramp_rate: int | None,
+        on_step: Callable[[int], None] | None,
+        stop: threading.Event,
+    ) -> None:
+        """Ramp loop running in a daemon thread. Blocking writes are intentional."""
+        limit_pct = max(MINIMUM_LIMIT, min(100, limit_pct))
+
+        current = self.get_power_limit().limit_pct
+        if current == limit_pct:
+            return
+
+        ramping_down = limit_pct < current
+        step_size = ramp_rate if ramp_rate is not None else RAMP_STEP
+        sleep_interval = RAMP_RATE_DOWN if ramping_down else RAMP_RATE_UP
+        direction = -step_size if ramping_down else step_size
+
+        next_val = current
+        while next_val != limit_pct and not stop.is_set():
+            next_val += direction
+            if (direction < 0 and next_val < limit_pct) or (direction > 0 and next_val > limit_pct):
+                next_val = limit_pct
+            next_val = max(MINIMUM_LIMIT, min(100, next_val))
+
+            self._write_power_limit(next_val)
+
+            if on_step is not None:
+                on_step(next_val)
+
+            if next_val != limit_pct:
+                # Use Event.wait() so the sleep is interruptible when stop is set.
+                stop.wait(timeout=sleep_interval)
+
+    def _write_power_limit(self, limit_pct: int) -> None:
+        """POST a single power limit step to the inverter.
+
+        M11 uses pwrlim.cgi; M10 uses adv.cgi. Hardware version is populated
+        after the first get_data() call.
+        """
+        endpoint = "adv.cgi" if self._is_m10() else "pwrlim.cgi"
+        data = {
+            "enlim": "on",
+            "ac_sys": "0",
+            "ac_mode": "1",
+            "ac_value1": str(limit_pct),
+            "ac_value2": "0",
+            "em_ml": "0",
+            "ac_value3": "60",
+            "drm_sp": "16.67",
+        }
+        try:
+            response = requests.post(
+                url=f"http://{self.host}/{endpoint}",
+                data=data,
+                timeout=self._timeout,
+            )
+        except requests.exceptions.ConnectionError:
+            # Inverter closes the TCP connection after processing the POST
+            # without sending an HTTP response — treat as success.
+            return
+        except requests.exceptions.Timeout as exception:
+            raise ZeverSolarTimeout() from exception
+        except Exception as exception:
+            raise ZeverSolarError() from exception
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exception:
+            if response.status_code == 404:
+                raise ZeverSolarHTTPNotFound() from exception
+            raise ZeverSolarHTTPError() from exception
+
+    def _is_m10(self) -> bool:
+        return self._hardware_version is not None and self._hardware_version.startswith("M10")
+
+    def power_on(self) -> PowerMode | None:
+        """Restore full output.
+
+        M10: hard on via inv_ctrl.cgi (existing behaviour).
+        M11: ramp to 100% via pwrlim.cgi.
+        Returns PowerMode.ON on M10, None on M11.
+        """
+        if self._is_m10():
+            return self.ctrl_power(mode=PowerMode.ON)
+        self.set_power_limit(100)
+        return None
+
+    def power_off(self) -> PowerMode | None:
+        """Reduce output to minimum.
+
+        M10: hard off via inv_ctrl.cgi (existing behaviour).
+        M11: ramp to MINIMUM_LIMIT% via pwrlim.cgi.
+        Returns PowerMode.OFF on M10, None on M11.
+        """
+        if self._is_m10():
+            return self.ctrl_power(mode=PowerMode.OFF)
+        self.set_power_limit(MINIMUM_LIMIT)
+        return None
 
     @retry.retry(exceptions=ZeverSolarTimeout, tries=3)  # pragma: no mutate
     def ctrl_power(self, mode: PowerMode) -> PowerMode:

--- a/src/zeversolar/__init__.py
+++ b/src/zeversolar/__init__.py
@@ -228,14 +228,16 @@ class ZeverSolarClient:
 
         # adv.cgi returns one field per line (0-indexed):
         #   line 11 = ac_value1 — current power limit %
-        #   line 13 = ac_mode   — active limit mode
+        #   line 12 = ac_value2
+        #   line 13 = ac_value3
+        #   line 14 = ac_mode   — active limit mode
         lines = response.text.splitlines()
-        if len(lines) < 14:
+        if len(lines) < 15:
             raise ZeverSolarInvalidData()
 
         try:
             limit_pct = int(float(lines[11].strip()))
-            mode = PowerLimitMode(int(lines[13].strip()))
+            mode = PowerLimitMode(int(lines[14].strip()))
         except (ValueError, KeyError) as exception:
             raise ZeverSolarInvalidData() from exception
 

--- a/src/zeversolar/__init__.py
+++ b/src/zeversolar/__init__.py
@@ -188,6 +188,7 @@ class ZeverSolarClient:
         self._serial_number: typing.Optional[str] = None
         self._hardware_version: typing.Optional[str] = None
         self._ramp_stop: threading.Event = threading.Event()
+        self._ramp_lock: threading.Lock = threading.Lock()
 
     @retry.retry(exceptions=(ZeverSolarTimeout, ZeverSolarInvalidData), tries=3)  # pragma: no mutate
     def get_data(self) -> ZeverSolarData:
@@ -260,17 +261,18 @@ class ZeverSolarClient:
         Sleep between steps is fixed by direction: RAMP_RATE_UP when
         increasing, RAMP_RATE_DOWN when decreasing.
         """
-        # Signal any running ramp to stop, then issue a fresh stop event for
-        # the new ramp so the old and new threads don't share state.
-        self._ramp_stop.set()
-        self._ramp_stop = threading.Event()
+        # Lock ensures stop+create+start is atomic — prevents two concurrent
+        # calls from each reading the same _ramp_stop before it is replaced.
+        with self._ramp_lock:
+            self._ramp_stop.set()
+            self._ramp_stop = threading.Event()
 
-        thread = threading.Thread(
-            target=self._do_ramp,
-            args=(limit_pct, ramp_rate, on_step, self._ramp_stop),
-            daemon=True,
-        )
-        thread.start()
+            thread = threading.Thread(
+                target=self._do_ramp,
+                args=(limit_pct, ramp_rate, on_step, self._ramp_stop),
+                daemon=True,
+            )
+            thread.start()
 
     def _do_ramp(
         self,
@@ -307,6 +309,7 @@ class ZeverSolarClient:
                 # Use Event.wait() so the sleep is interruptible when stop is set.
                 stop.wait(timeout=sleep_interval)
 
+    @retry.retry(exceptions=ZeverSolarTimeout, tries=3)  # pragma: no mutate
     def _write_power_limit(self, limit_pct: int) -> None:
         """POST a single power limit step to the inverter.
 
@@ -347,6 +350,8 @@ class ZeverSolarClient:
             raise ZeverSolarHTTPError() from exception
 
     def _is_m10(self) -> bool:
+        if self._hardware_version is None:
+            self.get_data()
         return self._hardware_version is not None and self._hardware_version.startswith("M10")
 
     def power_on(self) -> PowerMode | None:

--- a/src/zeversolar/exceptions.py
+++ b/src/zeversolar/exceptions.py
@@ -29,3 +29,9 @@ class ZeverSolarHTTPNotFound(ZeverSolarHTTPError):
     """
     Exception thrown when an HTTP Not Found (404) error occurs
     """
+
+
+class ZeverSolarPowerLimitNotSupported(ZeverSolarError):
+    """
+    Exception thrown when the inverter does not support power limiting
+    """

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/conftest.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/conftest.py
@@ -1,3 +1,5 @@
+import threading
+
 import pytest
 from pytest_mock import MockFixture
 
@@ -17,4 +19,6 @@ def instance(mocker: MockFixture):
         "host": mocker.Mock(spec=str),
         "_serial_number": None,
         "_timeout": mocker.Mock(spec=timedelta),
+        "_hardware_version": None,
+        "_ramp_stop": threading.Event(),
     })

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/conftest.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/conftest.py
@@ -21,4 +21,5 @@ def instance(mocker: MockFixture):
         "_timeout": mocker.Mock(spec=timedelta),
         "_hardware_version": None,
         "_ramp_stop": threading.Event(),
+        "_ramp_lock": threading.Lock(),
     })

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test___init__.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test___init__.py
@@ -1,3 +1,4 @@
+import threading
 from unittest.mock import call
 
 import pytest
@@ -19,7 +20,30 @@ def test___init__(mocker: pytest_mock.MockerFixture, host: str):
     assert fake.instance.host == fake_urllib.urlparse.return_value.netloc.strip.return_value
     assert fake.instance._timeout == 10
     assert fake.instance._serial_number is None
+    assert fake.instance._hardware_version is None
+    assert isinstance(fake.instance._ramp_stop, threading.Event)
     fake_urllib.assert_has_calls(calls=[
         call.urlparse(url=host),
         call.urlparse().netloc.strip("/"),
     ])
+
+
+@pytest.mark.parametrize(
+    argnames=("hardware_version", "expected"),
+    argvalues=(
+        ("M10", True),
+        ("M10A", True),   # variant M10 hardware still matches
+        ("M11", False),
+        ("M11A", False),
+        (None, False),    # not yet detected
+        ("", False),
+    ),
+)
+def test_is_m10(mocker: pytest_mock.MockerFixture, hardware_version: str | None, expected: bool):
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._hardware_version = hardware_version
+
+    result = ZeverSolarClient._is_m10(self=fake.instance)
+
+    assert result is expected

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test___init__.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test___init__.py
@@ -22,6 +22,7 @@ def test___init__(mocker: pytest_mock.MockerFixture, host: str):
     assert fake.instance._serial_number is None
     assert fake.instance._hardware_version is None
     assert isinstance(fake.instance._ramp_stop, threading.Event)
+    assert type(fake.instance._ramp_lock) is type(threading.Lock())
     fake_urllib.assert_has_calls(calls=[
         call.urlparse(url=host),
         call.urlparse().netloc.strip("/"),
@@ -35,11 +36,10 @@ def test___init__(mocker: pytest_mock.MockerFixture, host: str):
         ("M10A", True),   # variant M10 hardware still matches
         ("M11", False),
         ("M11A", False),
-        (None, False),    # not yet detected
         ("", False),
     ),
 )
-def test_is_m10(mocker: pytest_mock.MockerFixture, hardware_version: str | None, expected: bool):
+def test_is_m10(mocker: pytest_mock.MockerFixture, hardware_version: str, expected: bool):
     from zeversolar import ZeverSolarClient
     fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
     fake.instance._hardware_version = hardware_version
@@ -47,3 +47,21 @@ def test_is_m10(mocker: pytest_mock.MockerFixture, hardware_version: str | None,
     result = ZeverSolarClient._is_m10(self=fake.instance)
 
     assert result is expected
+    fake.instance.get_data.assert_not_called()
+
+
+def test_is_m10_fetches_hardware_version_when_unknown(mocker: pytest_mock.MockerFixture):
+    """If _hardware_version is None, get_data() is called to populate it."""
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._hardware_version = None
+
+    def populate_hardware_version():
+        fake.instance._hardware_version = "M11"
+
+    fake.instance.get_data.side_effect = populate_hardware_version
+
+    result = ZeverSolarClient._is_m10(self=fake.instance)
+
+    fake.instance.get_data.assert_called_once()
+    assert result is False

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test__write_power_limit.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test__write_power_limit.py
@@ -1,0 +1,86 @@
+import pytest
+import requests
+from unittest.mock import call, Mock
+
+from pytest_mock import MockFixture
+
+from zeversolar.exceptions import ZeverSolarError, ZeverSolarHTTPError, ZeverSolarHTTPNotFound, ZeverSolarTimeout
+
+
+@pytest.mark.parametrize(
+    argnames=("hardware_version", "expected_endpoint"),
+    argvalues=(
+        ("M11", "pwrlim.cgi"),
+        ("M10", "adv.cgi"),
+        (None, "pwrlim.cgi"),  # unknown hardware defaults to M11 endpoint
+    ),
+)
+def test_write_power_limit_endpoint_selection(
+    mocker: MockFixture,
+    instance: Mock,
+    hardware_version: str | None,
+    expected_endpoint: str,
+):
+    patched_post = mocker.patch("zeversolar.requests.post")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance._is_m10.return_value = hardware_version == "M10"
+
+    ZeverSolarClient._write_power_limit(self=fake.instance, limit_pct=75)
+
+    patched_post.assert_called_once_with(
+        url=f"http://{fake.instance.host}/{expected_endpoint}",
+        data={
+            "enlim": "on",
+            "ac_sys": "0",
+            "ac_mode": "1",
+            "ac_value1": "75",
+            "ac_value2": "0",
+            "em_ml": "0",
+            "ac_value3": "60",
+            "drm_sp": "16.67",
+        },
+        timeout=fake.instance._timeout,
+    )
+
+
+def test_write_power_limit_connection_closed_is_success(mocker: MockFixture, instance: Mock):
+    """Inverter closes TCP connection after processing — not an error."""
+    patched_post = mocker.patch("zeversolar.requests.post")
+    patched_post.side_effect = requests.exceptions.ConnectionError
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance._is_m10.return_value = False
+
+    ZeverSolarClient._write_power_limit(self=fake.instance, limit_pct=75)  # must not raise
+
+
+@pytest.mark.parametrize(
+    argnames="requests_side_effect,response_status,expected_exception",
+    argvalues=(
+        (Exception, None, ZeverSolarError),
+        (requests.exceptions.Timeout, None, ZeverSolarTimeout),
+        (requests.exceptions.HTTPError, 404, ZeverSolarHTTPNotFound),
+        (requests.exceptions.HTTPError, 500, ZeverSolarHTTPError),
+    ),
+)
+def test_write_power_limit_exception(
+    mocker: MockFixture,
+    requests_side_effect: type[Exception],
+    response_status: int | None,
+    expected_exception: type[Exception],
+    instance: Mock,
+):
+    patched_post = mocker.patch("zeversolar.requests.post")
+    if response_status is None:
+        patched_post.side_effect = [requests_side_effect]
+    else:
+        patched_post.return_value.raise_for_status.side_effect = [requests_side_effect]
+        patched_post.return_value.status_code = response_status
+
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance._is_m10.return_value = False
+
+    with pytest.raises(expected_exception):
+        ZeverSolarClient._write_power_limit(self=fake.instance, limit_pct=75)

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_data.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_data.py
@@ -31,6 +31,18 @@ def test_get_data(mocker: MockFixture, instance: Mock):
     ])
 
 
+def test_get_data_caches_hardware_version(mocker: MockFixture, instance: Mock):
+    """get_data() populates _hardware_version so set_power_limit can detect hardware."""
+    mocker.patch("zeversolar.requests.get")
+    patched_parser = mocker.patch("zeversolar.ZeverSolarParser")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    ZeverSolarClient.get_data(self=fake.instance)
+
+    assert fake.instance._hardware_version is patched_parser.return_value.parse.return_value.hardware_version
+
+
 @pytest.mark.parametrize(
     argnames="requests_side_effect,response_status,expected_exception",
     argvalues=(

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_power_limit.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_power_limit.py
@@ -14,13 +14,18 @@ from zeversolar.exceptions import (
     ZeverSolarTimeout,
 )
 
-# adv.cgi response: one field per line; line 11 (0-indexed) = ac_value1, line 13 = ac_mode
+# adv.cgi response: one field per line (0-indexed):
+#   line 11 = ac_value1 — current power limit %
+#   line 12 = ac_value2
+#   line 13 = ac_value3
+#   line 14 = ac_mode   — active limit mode
 _ADV_CGI_RESPONSE = "\n".join([
     "line0", "line1", "line2", "line3", "line4", "line5",
     "line6", "line7", "line8", "line9", "line10",
     "75",        # line 11 — ac_value1 (power limit %)
-    "line12",
-    "1",         # line 13 — ac_mode (1 = PERCENTAGE)
+    "line12",    # line 12 — ac_value2
+    "line13",    # line 13 — ac_value3
+    "1",         # line 14 — ac_mode (1 = PERCENTAGE)
 ])
 
 
@@ -84,8 +89,8 @@ def test_get_power_limit_invalid_data_too_few_lines(mocker: MockFixture, instanc
 @pytest.mark.parametrize(
     argnames="bad_response",
     argvalues=(
-        "\n".join(["x"] * 11 + ["not_a_number"] + ["x"] + ["1"]),  # ac_value1 not numeric
-        "\n".join(["x"] * 11 + ["75"] + ["x"] + ["99"]),           # ac_mode not a valid PowerLimitMode
+        "\n".join(["x"] * 11 + ["not_a_number"] + ["x"] + ["x"] + ["1"]),  # ac_value1 not numeric
+        "\n".join(["x"] * 11 + ["75"] + ["x"] + ["x"] + ["99"]),         # ac_mode not a valid PowerLimitMode
     ),
 )
 def test_get_power_limit_invalid_data_unparseable_fields(

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_power_limit.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_get_power_limit.py
@@ -1,0 +1,103 @@
+import pytest
+import requests
+import typing
+from unittest.mock import call, Mock
+
+from pytest_mock import MockFixture
+
+from zeversolar import PowerLimitMode, ZeverSolarPowerLimitData
+from zeversolar.exceptions import (
+    ZeverSolarError,
+    ZeverSolarHTTPError,
+    ZeverSolarInvalidData,
+    ZeverSolarPowerLimitNotSupported,
+    ZeverSolarTimeout,
+)
+
+# adv.cgi response: one field per line; line 11 (0-indexed) = ac_value1, line 13 = ac_mode
+_ADV_CGI_RESPONSE = "\n".join([
+    "line0", "line1", "line2", "line3", "line4", "line5",
+    "line6", "line7", "line8", "line9", "line10",
+    "75",        # line 11 — ac_value1 (power limit %)
+    "line12",
+    "1",         # line 13 — ac_mode (1 = PERCENTAGE)
+])
+
+
+def test_get_power_limit(mocker: MockFixture, instance: Mock):
+    patched_get = mocker.patch("zeversolar.requests.get")
+    patched_get.return_value.text = _ADV_CGI_RESPONSE
+
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    result = ZeverSolarClient.get_power_limit(self=fake.instance)
+
+    patched_get.assert_called_once_with(
+        url=f"http://{fake.instance.host}/adv.cgi",
+        timeout=fake.instance._timeout,
+    )
+    assert result == ZeverSolarPowerLimitData(mode=PowerLimitMode.PERCENTAGE, limit_pct=75)
+
+
+@pytest.mark.parametrize(
+    argnames="requests_side_effect,response_status,expected_exception",
+    argvalues=(
+        (Exception, None, ZeverSolarError),
+        (requests.exceptions.Timeout, None, ZeverSolarTimeout),
+        (requests.exceptions.HTTPError, 404, ZeverSolarPowerLimitNotSupported),
+        (requests.exceptions.HTTPError, 500, ZeverSolarHTTPError),
+    ),
+)
+def test_get_power_limit_exception(
+    mocker: MockFixture,
+    requests_side_effect: type[Exception],
+    response_status: typing.Optional[int],
+    expected_exception: type[Exception],
+    instance: Mock,
+):
+    patched_get = mocker.patch("zeversolar.requests.get")
+    if response_status is None:
+        patched_get.side_effect = [requests_side_effect]
+    else:
+        patched_get.return_value.raise_for_status.side_effect = [requests_side_effect]
+        patched_get.return_value.status_code = response_status
+
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    with pytest.raises(expected_exception):
+        ZeverSolarClient.get_power_limit(self=fake.instance)
+
+
+def test_get_power_limit_invalid_data_too_few_lines(mocker: MockFixture, instance: Mock):
+    patched_get = mocker.patch("zeversolar.requests.get")
+    patched_get.return_value.text = "too\nfew\nlines"
+
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    with pytest.raises(ZeverSolarInvalidData):
+        ZeverSolarClient.get_power_limit(self=fake.instance)
+
+
+@pytest.mark.parametrize(
+    argnames="bad_response",
+    argvalues=(
+        "\n".join(["x"] * 11 + ["not_a_number"] + ["x"] + ["1"]),  # ac_value1 not numeric
+        "\n".join(["x"] * 11 + ["75"] + ["x"] + ["99"]),           # ac_mode not a valid PowerLimitMode
+    ),
+)
+def test_get_power_limit_invalid_data_unparseable_fields(
+    mocker: MockFixture,
+    instance: Mock,
+    bad_response: str,
+):
+    patched_get = mocker.patch("zeversolar.requests.get")
+    patched_get.return_value.text = bad_response
+
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    with pytest.raises(ZeverSolarInvalidData):
+        ZeverSolarClient.get_power_limit(self=fake.instance)

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_power_off.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_power_off.py
@@ -1,15 +1,28 @@
 from unittest.mock import call
 
+import pytest
 from pytest_mock import MockFixture
 
 
-def test_power_off(mocker: MockFixture):
+def test_power_off_m10(mocker: MockFixture):
+    """M10: delegates to ctrl_power and returns PowerMode."""
     from zeversolar import ZeverSolarClient, PowerMode
-    fake = mocker.Mock(**{
-        "instance": mocker.Mock(spec=ZeverSolarClient),
-    })
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._is_m10.return_value = True
 
     result = ZeverSolarClient.power_off(self=fake.instance)
 
-    assert result is fake.instance.ctrl_power.return_value
     fake.instance.assert_has_calls(calls=[call.ctrl_power(mode=PowerMode.OFF)])
+    assert result is fake.instance.ctrl_power.return_value
+
+
+def test_power_off_m11(mocker: MockFixture):
+    """M11: ramps to MINIMUM_LIMIT via set_power_limit, returns None."""
+    from zeversolar import ZeverSolarClient, MINIMUM_LIMIT
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._is_m10.return_value = False
+
+    result = ZeverSolarClient.power_off(self=fake.instance)
+
+    fake.instance.assert_has_calls(calls=[call.set_power_limit(MINIMUM_LIMIT)])
+    assert result is None

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_power_on.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_power_on.py
@@ -1,15 +1,28 @@
 from unittest.mock import call
 
+import pytest
 from pytest_mock import MockFixture
 
 
-def test_power_on(mocker: MockFixture):
+def test_power_on_m10(mocker: MockFixture):
+    """M10: delegates to ctrl_power and returns PowerMode."""
     from zeversolar import ZeverSolarClient, PowerMode
-    fake = mocker.Mock(**{
-        "instance": mocker.Mock(spec=ZeverSolarClient),
-    })
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._is_m10.return_value = True
 
     result = ZeverSolarClient.power_on(self=fake.instance)
 
-    assert result is fake.instance.ctrl_power.return_value
     fake.instance.assert_has_calls(calls=[call.ctrl_power(mode=PowerMode.ON)])
+    assert result is fake.instance.ctrl_power.return_value
+
+
+def test_power_on_m11(mocker: MockFixture):
+    """M11: ramps to 100% via set_power_limit, returns None."""
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=mocker.Mock(spec=ZeverSolarClient))
+    fake.instance._is_m10.return_value = False
+
+    result = ZeverSolarClient.power_on(self=fake.instance)
+
+    fake.instance.assert_has_calls(calls=[call.set_power_limit(100)])
+    assert result is None

--- a/tests/unit_tests/zeversolar/ZeverSolarClient/test_set_power_limit.py
+++ b/tests/unit_tests/zeversolar/ZeverSolarClient/test_set_power_limit.py
@@ -1,0 +1,192 @@
+import threading
+from unittest.mock import Mock, call
+
+import pytest
+from pytest_mock import MockFixture
+
+from zeversolar import PowerLimitMode, ZeverSolarPowerLimitData, MINIMUM_LIMIT, RAMP_STEP, RAMP_RATE_UP, RAMP_RATE_DOWN
+
+
+def _make_power_limit_data(limit_pct: int) -> ZeverSolarPowerLimitData:
+    return ZeverSolarPowerLimitData(mode=PowerLimitMode.PERCENTAGE, limit_pct=limit_pct)
+
+
+def _run_do_ramp(client_instance, limit_pct, ramp_rate=None, on_step=None, stop=None):
+    """Call _do_ramp directly in the test thread with a fresh stop event."""
+    from zeversolar import ZeverSolarClient
+    stop = stop or threading.Event()
+    ZeverSolarClient._do_ramp(
+        self=client_instance,
+        limit_pct=limit_pct,
+        ramp_rate=ramp_rate,
+        on_step=on_step,
+        stop=stop,
+    )
+
+
+# --- set_power_limit: threading behaviour ---
+
+def test_set_power_limit_returns_immediately(mocker: MockFixture, instance: Mock):
+    """set_power_limit starts a thread and returns without waiting."""
+    mocker.patch("zeversolar.threading.Thread")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+
+    ZeverSolarClient.set_power_limit(self=fake.instance, limit_pct=50)
+    # If we get here the call did not block
+
+
+def test_set_power_limit_cancels_previous_ramp(mocker: MockFixture, instance: Mock):
+    """A second call signals the first ramp's stop event before starting a new thread."""
+    mocker.patch("zeversolar.threading.Thread")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    first_stop = threading.Event()
+    fake.instance._ramp_stop = first_stop
+
+    ZeverSolarClient.set_power_limit(self=fake.instance, limit_pct=50)
+
+    assert first_stop.is_set()
+
+
+# --- _do_ramp: ramp logic ---
+
+def test_do_ramp_no_change(mocker: MockFixture, instance: Mock):
+    """No writes when current == target."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(50)
+
+    _run_do_ramp(fake.instance, limit_pct=50)
+
+    fake.instance._write_power_limit.assert_not_called()
+
+
+def test_do_ramp_ramp_up(mocker: MockFixture, instance: Mock):
+    """Ramping up from 30% to 50% writes two 10% steps, waits RAMP_RATE_UP between them."""
+    patched_wait = mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+
+    _run_do_ramp(fake.instance, limit_pct=50)
+
+    assert fake.instance._write_power_limit.call_args_list == [call(40), call(50)]
+    patched_wait.assert_called_once_with(timeout=RAMP_RATE_UP)
+
+
+def test_do_ramp_ramp_down(mocker: MockFixture, instance: Mock):
+    """Ramping down from 80% to 60% writes two 10% steps, waits RAMP_RATE_DOWN between them."""
+    patched_wait = mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(80)
+
+    _run_do_ramp(fake.instance, limit_pct=60)
+
+    assert fake.instance._write_power_limit.call_args_list == [call(70), call(60)]
+    patched_wait.assert_called_once_with(timeout=RAMP_RATE_DOWN)
+
+
+def test_do_ramp_ramp_rate_controls_step_size(mocker: MockFixture, instance: Mock):
+    """ramp_rate=5 gives finer 5% steps."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+
+    _run_do_ramp(fake.instance, limit_pct=50, ramp_rate=5)
+
+    assert fake.instance._write_power_limit.call_args_list == [
+        call(35), call(40), call(45), call(50)
+    ]
+
+
+def test_do_ramp_ramp_rate_100_jumps_directly(mocker: MockFixture, instance: Mock):
+    """ramp_rate=100 results in a single write — no sleep."""
+    patched_wait = mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+
+    _run_do_ramp(fake.instance, limit_pct=80, ramp_rate=100)
+
+    assert fake.instance._write_power_limit.call_args_list == [call(80)]
+    patched_wait.assert_not_called()
+
+
+def test_do_ramp_clamps_to_minimum(mocker: MockFixture, instance: Mock):
+    """Target below MINIMUM_LIMIT is clamped."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(100)
+
+    _run_do_ramp(fake.instance, limit_pct=0)
+
+    last_call = fake.instance._write_power_limit.call_args_list[-1]
+    assert last_call == call(MINIMUM_LIMIT)
+
+
+def test_do_ramp_clamps_to_maximum(mocker: MockFixture, instance: Mock):
+    """Target above 100 is clamped to 100."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(50)
+
+    _run_do_ramp(fake.instance, limit_pct=200)
+
+    last_call = fake.instance._write_power_limit.call_args_list[-1]
+    assert last_call == call(100)
+
+
+def test_do_ramp_on_step_called(mocker: MockFixture, instance: Mock):
+    """on_step is called after each write with the new value."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+    on_step = mocker.Mock()
+
+    _run_do_ramp(fake.instance, limit_pct=50, on_step=on_step)
+
+    assert on_step.call_args_list == [call(40), call(50)]
+
+
+def test_do_ramp_write_failure_propagates(mocker: MockFixture, instance: Mock):
+    """If _write_power_limit raises mid-ramp the exception propagates out of the thread."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    from zeversolar.exceptions import ZeverSolarError
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+    fake.instance._write_power_limit.side_effect = ZeverSolarError("inverter gone")
+
+    with pytest.raises(ZeverSolarError):
+        _run_do_ramp(fake.instance, limit_pct=60)
+
+    # Only attempted the first step before raising
+    assert fake.instance._write_power_limit.call_count == 1
+
+
+def test_do_ramp_stops_when_event_set(mocker: MockFixture, instance: Mock):
+    """Ramp exits cleanly after the current step when stop event is set."""
+    mocker.patch("zeversolar.threading.Event.wait")
+    from zeversolar import ZeverSolarClient
+    fake = mocker.Mock(instance=instance)
+    fake.instance.get_power_limit.return_value = _make_power_limit_data(30)
+
+    stop = threading.Event()
+
+    def write_and_stop(val: int) -> None:
+        # Simulate cancellation arriving after the first write
+        stop.set()
+
+    fake.instance._write_power_limit.side_effect = write_and_stop
+
+    _run_do_ramp(fake.instance, limit_pct=60, stop=stop)
+
+    # Only the first step (40%) was written; loop exited before writing 50% or 60%
+    assert fake.instance._write_power_limit.call_args_list == [call(40)]


### PR DESCRIPTION
# Add power limit read/write support (M10/M11 hardware-aware)

Closes #49

Adds the ability to read and control the inverter's power output limit.
Tested on M11 hardware via network traffic analysis. M10 write path uses
`adv.cgi` as the POST target — the same endpoint confirmed readable on
both hardware versions.

## New API

### Reading the current limit

```python
client = ZeverSolarClient(host="192.168.1.100")
data = client.get_power_limit()
print(data.limit_pct)   # e.g. 75
print(data.mode)        # PowerLimitMode.PERCENTAGE
```

Reads `adv.cgi`. Works on M10 and M11. Raises
`ZeverSolarPowerLimitNotSupported` if the inverter returns 404.

### Setting the limit (with ramp)

```python
# Ramp to 50% in default 10% steps
client.set_power_limit(50)

# Jump directly to 50% in a single write (no intermediate steps)
client.set_power_limit(50, ramp_rate=100)

# Finer 5% steps for a more gradual transition
client.set_power_limit(50, ramp_rate=5)

# Get notified after each step (e.g. for real-time UI updates)
def on_step(value: int) -> None:
    print(f"Power limit now at {value}%")

client.set_power_limit(50, on_step=on_step)
```

`set_power_limit()` returns immediately. The ramp runs in a daemon
thread so the caller is never blocked. Calling `set_power_limit()`
again while a ramp is in progress cancels the old ramp cleanly — the
current write completes before the thread exits — and starts a new one
from wherever the inverter actually is at that moment.

Sleep between steps is fixed by direction:
- Ramping up: 10 s between steps
- Ramping down: 20 s between steps (slower = safer for grid stability)

### Turning output on and off

```python
# Restore full output (ramp to 100%)
client.power_on()

# Reduce output to minimum (ramp to MINIMUM_LIMIT = 5%)
client.power_off()
```

`power_on()` and `power_off()` dispatch based on hardware version
(cached after the first `get_data()` call):

- **M10**: hard on/off via `inv_ctrl.cgi` — behaviour unchanged from previous releases
- **M11**: ramps to 100% / `MINIMUM_LIMIT`% via `pwrlim.cgi`

On M11, these previously raised `ZeverSolarHTTPNotFound` because
`inv_ctrl.cgi` does not exist on that hardware. They now work correctly.

## Constants

| Constant | Value | Meaning |
|---|---|---|
| `MINIMUM_LIMIT` | 5 | Minimum accepted % on M11 |
| `RAMP_STEP` | 10 | Default step size in % |
| `RAMP_RATE_UP` | 10 | Seconds between steps when increasing |
| `RAMP_RATE_DOWN` | 20 | Seconds between steps when decreasing |

## Exceptions

| Exception | When raised |
|---|---|
| `ZeverSolarPowerLimitNotSupported` | `get_power_limit()` receives a 404 — hardware does not support power limiting |

## Notes on return type

`power_on()` and `power_off()` now return `PowerMode | None` instead of
`PowerMode`. On M10 the return value is unchanged. On M11 they return
`None` (previously they raised an exception, so no existing code could
have depended on the return value).

## Testing

80 tests, 100% line coverage. Both M10 and M11 paths are covered
explicitly for all write operations, including the ramp cancellation
safety guarantee.
