### PR TITLE
fix: revert @retry on _write_power_limit and _is_m10 auto-fetch

### DIFF
--- a/probe.py
+++ b/probe.py
@@ -1,13 +1,9 @@
 """Command-line probe: test the zeversolar library against a real inverter.
 
 Usage:
-    python probe.py <host> [--write]
-    python probe.py 192.168.2.22
-    python probe.py 192.168.2.22 --write   # also tests write path (restores state)
-
-Read-only by default. Pass --write to also exercise set_power_limit, which
-will temporarily change the limit to 90% and then restore the original value.
-The device is always left in the state it was found in.
+    poetry run python probe.py <host> --basic      # Test 1: read basic inverter data
+    poetry run python probe.py <host> --full       # Test 2: read all data including power limit
+    poetry run python probe.py <host> --write      # Test 3: curtail to 90%, restore to 100%
 """
 
 import sys
@@ -18,7 +14,7 @@ import urllib.parse
 import requests
 
 from zeversolar import ZeverSolarClient, ZeverSolarPowerLimitData
-from zeversolar.exceptions import ZeverSolarInvalidData, ZeverSolarPowerLimitNotSupported
+from zeversolar.exceptions import ZeverSolarInvalidData, ZeverSolarPowerLimitNotSupported, ZeverSolarTimeout
 
 
 def fetch_raw(host: str, path: str) -> str:
@@ -36,62 +32,50 @@ def print_fields(obj: object) -> None:
 
 
 def wait_for_limit(client: ZeverSolarClient, target_pct: int, timeout: int = 120) -> bool:
-    """Poll get_power_limit() until it reaches target_pct or timeout expires."""
+    """Poll get_power_limit() until it reaches target_pct or timeout expires.
+
+    Transient timeouts (inverter temporarily offline after a write) are caught
+    and retried — the inverter typically recovers within a few seconds.
+    """
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        current = client.get_power_limit().limit_pct
-        print(f"  ... {current}%")
-        if current == target_pct:
-            return True
+        try:
+            current = client.get_power_limit().limit_pct
+            print(f"  ... {current}%")
+            if current == target_pct:
+                return True
+        except ZeverSolarTimeout:
+            print("  ... (inverter temporarily unreachable, retrying)")
         time.sleep(5)
     return False
 
 
-def test_write(client: ZeverSolarClient, original: ZeverSolarPowerLimitData) -> None:
-    """Exercise set_power_limit and restore state unconditionally."""
-    target = 90 if original.limit_pct != 90 else 80
-    print(f"\n=== set_power_limit({target}%) ===")
-    print(f"  Saving original: limit_pct={original.limit_pct}, mode={original.mode}")
-    try:
-        client.set_power_limit(target)
-        if wait_for_limit(client, target):
-            print("  Write verified ✓")
-        else:
-            print(f"  Timed out waiting for {target}%")
-    finally:
-        print(f"\n=== Restoring original limit ({original.limit_pct}%) ===")
-        client.set_power_limit(original.limit_pct)
-        if wait_for_limit(client, original.limit_pct):
-            print("  Restore verified ✓")
-        else:
-            print(f"  WARNING: restore timed out (readback may not be {original.limit_pct}%)")
+def test_basic(host: str) -> None:
+    """Test 1: read basic inverter data via get_data()."""
+    print(f"=== Test 1: basic read ({host}) ===\n")
+    client = ZeverSolarClient(host=host)
+    data = client.get_data()
+    print_fields(data)
+    print("\nTest 1 passed ✓")
 
 
-def main() -> None:
-    if len(sys.argv) < 2:
-        print("Usage: python probe.py <host> [--write]")
-        print("Example: python probe.py 192.168.2.22")
-        sys.exit(1)
-
-    host = sys.argv[1]
-    write_mode = "--write" in sys.argv
-    print(f"Connecting to {host} ...\n")
-
+def test_full(host: str) -> None:
+    """Test 2: read all data including power limit."""
+    print(f"=== Test 2: full read ({host}) ===\n")
     client = ZeverSolarClient(host=host)
 
-    print("=== get_data() ===")
+    print("--- get_data() ---")
     data = client.get_data()
     print_fields(data)
 
-    print("\n=== get_power_limit() ===")
-    original_limit = None
+    print("\n--- get_power_limit() ---")
     try:
-        original_limit = client.get_power_limit()
-        print_fields(original_limit)
+        limit = client.get_power_limit()
+        print_fields(limit)
     except ZeverSolarPowerLimitNotSupported:
         print("  Not supported by this inverter.")
     except ZeverSolarInvalidData:
-        print("  ZeverSolarInvalidData — raw adv.cgi response follows for diagnosis:")
+        print("  ZeverSolarInvalidData — raw adv.cgi response:")
         try:
             raw = fetch_raw(host, "adv.cgi")
             for i, line in enumerate(raw.splitlines()):
@@ -99,11 +83,54 @@ def main() -> None:
         except Exception as exc:
             print(f"  Could not fetch adv.cgi: {exc}")
 
-    if write_mode:
-        if original_limit is None:
-            print("\n--write skipped: get_power_limit() failed above.")
+    print("\nTest 2 passed ✓")
+
+
+def test_write(host: str) -> None:
+    """Test 3: curtail output to 90%, then restore to 100%."""
+    print(f"=== Test 3: write test ({host}) ===\n")
+    client = ZeverSolarClient(host=host)
+
+    print("--- Reading current limit ---")
+    original = client.get_power_limit()
+    print_fields(original)
+
+    print("\n--- Curtailing to 90% ---")
+    try:
+        client.set_power_limit(90)
+        if wait_for_limit(client, 90):
+            print("  Curtail to 90% verified ✓")
         else:
-            test_write(client, original_limit)
+            print("  WARNING: timed out waiting for 90%")
+    finally:
+        print("\n--- Restoring to 100% ---")
+        client.set_power_limit(100)
+        if wait_for_limit(client, 100):
+            print("  Restore to 100% verified ✓")
+        else:
+            print("  WARNING: restore timed out")
+
+    print("\nTest 3 passed ✓")
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        print(__doc__)
+        sys.exit(1)
+
+    host = sys.argv[1]
+    mode = sys.argv[2]
+
+    if mode == "--basic":
+        test_basic(host)
+    elif mode == "--full":
+        test_full(host)
+    elif mode == "--write":
+        test_write(host)
+    else:
+        print(f"Unknown mode: {mode}")
+        print(__doc__)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/zeversolar/__init__.py
+++ b/src/zeversolar/__init__.py
@@ -311,7 +311,6 @@ class ZeverSolarClient:
                 # Use Event.wait() so the sleep is interruptible when stop is set.
                 stop.wait(timeout=sleep_interval)
 
-    @retry.retry(exceptions=ZeverSolarTimeout, tries=3)  # pragma: no mutate
     def _write_power_limit(self, limit_pct: int) -> None:
         """POST a single power limit step to the inverter.
 


### PR DESCRIPTION
Hi all,

Fixing something I broke

I tested 0.4.0 release of the library against my M11 hardware inverter. Unfortunately writing to the inverter made the server become unavailable/unreachable. I missed this in my unit mock testing. 

Root cause 1: @retry on _write_power_limit — the M11 web server briefly restarts after a successful write to pwrlim.cgi. That restart looks like a ZeverSolarTimeout but isn't a transient error — it confirms the write landed. With @retry(tries=3), the library sends up to 3 duplicate POSTs during the restart window, compounding the disruption.

Root cause 2: _is_m10 auto-fetch — adds an extra get_data() call inside _write_power_limit before every write. In real deployments the hardware version is always populated before writing (the coordinator fetches data first), so this call is never needed. It also adds an HTTP round-trip during the already-sensitive post-write window.

What's kept — the threading lock from the same commit is correct and stays.

What's reverted — _write_power_limit and _is_m10 back to their ced5fd2 state. One test (test_is_m10_fetches_hardware_version_when_unknown) removed as it tested the removed behaviour.
Evidence it works — 79/79 unit tests pass; real-inverter probe test completes cleanly (100% → 90% → 100% with no timeouts).

Both changes were added in fa1a189 in response to Gemini code review but cause real-world failures on M11 hardware:
